### PR TITLE
Remove company mention from Palala's bio

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,7 +563,6 @@
                                         <h4>Getting Wordpress OOP by using Corcel</h4>
 
                                         <h5>Joe Palala</h5>
-                                        <h6>Pykotech</h6>
 
                                         <p>Working with Wordpress and learning to find out about wordpress hooks and then overriding functions can lead to spaghetti code. I'll share about using a PHP library known as Corcel that will make working with wordpress less of a pain.</p>
 


### PR DESCRIPTION
As per email by speaker on Wed, 18 Jul 2018 at 11:08 PM SGT.

Not replacing with generic "Software Developer/Designer" title as inconsistent, and that there is also a precedent of another speaker with no mention of company.